### PR TITLE
Fixed chart size on mobile devices

### DIFF
--- a/src/components/Chart/Chart.jsx
+++ b/src/components/Chart/Chart.jsx
@@ -1,69 +1,77 @@
-import React, { useState, useEffect } from 'react';
-import { fetchDailyData } from '../../api/index';
-import { Line, Bar } from 'react-chartjs-2';
+import React, { useState, useEffect } from "react";
+import { fetchDailyData } from "../../api/index";
+import { Line, Bar } from "react-chartjs-2";
 
-import styles from './Chart.module.css';
+import styles from "./Chart.module.css";
 
 const Chart = ({ data: { confirmed, recovered, deaths }, country }) => {
-	const [dailyData, setDailyData] = useState({});
+  const [dailyData, setDailyData] = useState({});
 
-	useEffect(() => {
-		const fetchMyAPI = async () => {
-			const initialDailyData = await fetchDailyData();
+  useEffect(() => {
+    const fetchMyAPI = async () => {
+      const initialDailyData = await fetchDailyData();
 
-			setDailyData(initialDailyData);
-		};
+      setDailyData(initialDailyData);
+    };
 
-		fetchMyAPI();
-	}, []);
+    fetchMyAPI();
+  }, []);
 
-	const barChart = confirmed ? (
-		<Bar
-			data={{
-				labels: ['Infected', 'Recovered', 'Deaths'],
-				datasets: [
-					{
-						label: 'People',
-						backgroundColor: [
-							'rgba(0, 0, 255, 0.5)',
-							'rgba(0, 255, 0, 0.5)',
-							'rgba(255, 0, 0, 0.5)',
-						],
-						data: [confirmed.value, recovered.value, deaths.value],
-					},
-				],
-			}}
-			options={{
-				legend: { display: false },
-				title: { display: true, text: `Current state in ${country}` },
-			}}
-		/>
-	) : null;
+  const barChart = confirmed ? (
+    <Bar
+      data={{
+        labels: ["Infected", "Recovered", "Deaths"],
+        datasets: [
+          {
+            label: "People",
+            backgroundColor: [
+              "rgba(0, 0, 255, 0.5)",
+              "rgba(0, 255, 0, 0.5)",
+              "rgba(255, 0, 0, 0.5)",
+            ],
+            data: [confirmed.value, recovered.value, deaths.value],
+          },
+        ],
+      }}
+      options={{
+        legend: { display: false },
+        title: { display: true, text: `Current state in ${country}` },
+        responsive: true,
+        maintainAspectRatio: false,
+      }}
+    />
+  ) : null;
 
-	const lineChart = dailyData[0] ? (
-		<Line
-			data={{
-				labels: dailyData.map(({ date }) => date),
-				datasets: [
-					{
-						data: dailyData.map((data) => data.confirmed),
-						label: 'Infected',
-						borderColor: '#3333ff',
-						fill: true,
-					},
-					{
-						data: dailyData.map((data) => data.deaths),
-						label: 'Deaths',
-						borderColor: 'red',
-						backgroundColor: 'rgba(255, 0, 0, 0.5)',
-						fill: true,
-					},
-				],
-			}}
-		/>
-	) : null;
+  const lineChart = dailyData[0] ? (
+    <Line
+      data={{
+        labels: dailyData.map(({ date }) => date),
+        datasets: [
+          {
+            data: dailyData.map((data) => data.confirmed),
+            label: "Infected",
+            borderColor: "#3333ff",
+            fill: true,
+          },
+          {
+            data: dailyData.map((data) => data.deaths),
+            label: "Deaths",
+            borderColor: "red",
+            backgroundColor: "rgba(255, 0, 0, 0.5)",
+            fill: true,
+          },
+        ],
+      }}
+      options={{
+        responsive: true,
+        maintainAspectRatio: false,
+      }}
+    />
+  ) : null;
 
-	return <div className={styles.container}>{country ? barChart : lineChart}</div>;
+  return (
+    <div className={styles.container}>{country ? barChart : lineChart}</div>
+  );
 };
 
 export default Chart;

--- a/src/components/Chart/Chart.module.css
+++ b/src/components/Chart/Chart.module.css
@@ -1,11 +1,12 @@
 .container {
-	display: flex;
-	justify-content: center;
-	width: 65%;
+  display: flex;
+  justify-content: center;
+  width: 65%;
 }
 
 @media only screen and (max-width: 770px) {
-	.container {
-		width: 100%;
-	}
+  .container {
+    width: 100%;
+    height: 400px;
+  }
 }


### PR DESCRIPTION
Line chart was __unreadable__ on mobile devices.

Increased the height of the chart container at the media screen level (applies to both charts)

Added extra configure options in both Bar and Line charts for aspect ratio and responsiveness

